### PR TITLE
Optimised regex in lib_filter::process_remove_blanks()

### DIFF
--- a/lib_filter.php
+++ b/lib_filter.php
@@ -331,11 +331,13 @@
 
 		function process_remove_blanks($data){
 
-			foreach($this->remove_blanks as $tag){
-
-				$data = preg_replace("/<{$tag}(\s[^>]*)?><\\/{$tag}>/", '', $data);
-				$data = preg_replace("/<{$tag}(\s[^>]*)?\\/>/", '', $data);
+			if (empty($this->remove_blanks)) {
+				return $data;
 			}
+
+			$tags = implode('|', $this->remove_blanks);
+			$data = preg_replace("/<({$tags})(\s[^>]*)?(><\\/\\1>|\\/>)/", '', $data);
+
 			return $data;
 		}
 


### PR DESCRIPTION
If you want to remove a lot of blank tags, there were previously two preg_replace calls for each tag. This patch changes it to one preg_replace call for any number of tags.
